### PR TITLE
feat: Use strpos for replacement

### DIFF
--- a/Classes/NodeSearchService.php
+++ b/Classes/NodeSearchService.php
@@ -109,7 +109,11 @@ class NodeSearchService implements NodeSearchServiceInterface
         array_walk_recursive(
             $request,
             static function (&$value) use ($replacements) {
-                $value = $replacements[$value] ?? $value;
+                foreach ($replacements as $replacementKey => $replacement) {
+                    if (strpos($value, $replacementKey)) {
+                        $value = str_replace($replacementKey, $replacement, $value);
+                    }
+                }
             }
         );
 


### PR DESCRIPTION
Use strpos for the replacement.
Allows to use additional static terms in a query term